### PR TITLE
Envío parámetro para paginación

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/anthos/rick_and_morty/data/remote/api/RickAndMortyApi.kt
+++ b/app/src/main/java/com/anthos/rick_and_morty/data/remote/api/RickAndMortyApi.kt
@@ -2,8 +2,9 @@ package com.anthos.rick_and_morty.data.remote.api
 
 import com.anthos.rick_and_morty.data.remote.model.CharactersApiModel
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface RickAndMortyApi {
     @GET("character")
-    suspend fun getCharacters(): CharactersApiModel
+    suspend fun getCharacters(@Query("page") page: Int): CharactersApiModel
 }

--- a/app/src/main/java/com/anthos/rick_and_morty/data/remote/model/CharactersApiModel.kt
+++ b/app/src/main/java/com/anthos/rick_and_morty/data/remote/model/CharactersApiModel.kt
@@ -1,8 +1,10 @@
 package com.anthos.rick_and_morty.data.remote.model
 
+import com.anthos.rick_and_morty.data.remote.model.Constants.INFO
 import com.anthos.rick_and_morty.data.remote.model.Constants.RESULTS
 import com.google.gson.annotations.SerializedName
 
 data class CharactersApiModel(
-    @SerializedName(RESULTS) val results: List<CharacterApiModel>
+    @SerializedName(RESULTS) val results: List<CharacterApiModel?>?,
+    @SerializedName(INFO) val info: InfoApiModel?
 )

--- a/app/src/main/java/com/anthos/rick_and_morty/data/remote/model/Constants.kt
+++ b/app/src/main/java/com/anthos/rick_and_morty/data/remote/model/Constants.kt
@@ -14,4 +14,10 @@ object Constants {
     const val LOCATION = "location"
     const val EPISODE = "episode"
     const val CREATED = "created"
+    const val COUNT = "count"
+    const val PAGES = "pages"
+    const val NEXT = "next"
+    const val PREV = "prev"
+    const val INFO = "info"
+
 }

--- a/app/src/main/java/com/anthos/rick_and_morty/data/remote/model/InfoApiModel.kt
+++ b/app/src/main/java/com/anthos/rick_and_morty/data/remote/model/InfoApiModel.kt
@@ -1,0 +1,14 @@
+package com.anthos.rick_and_morty.data.remote.model
+
+import com.anthos.rick_and_morty.data.remote.model.Constants.COUNT
+import com.anthos.rick_and_morty.data.remote.model.Constants.NEXT
+import com.anthos.rick_and_morty.data.remote.model.Constants.PAGES
+import com.anthos.rick_and_morty.data.remote.model.Constants.PREV
+import com.google.gson.annotations.SerializedName
+
+data class InfoApiModel(
+    @SerializedName(COUNT) val count: Int?,
+    @SerializedName(PAGES) val pages: Int?,
+    @SerializedName(NEXT) val next: String?,
+    @SerializedName(PREV) val prev: String?
+)


### PR DESCRIPTION
Se agrega parámetro info en el modelo CharactersApiModel.kt.
Se agrega parámetro para permitir paginación.

La información para agregar el parámetro en la paginación con `@Query` se obtuvo de la pagina oficial de [Retrofit](https://square.github.io/retrofit/)

Tarea: [[Data][Api] enviar parametro para la paginación](https://github.com/orgs/Android-Anthos/projects/1/views/1?pane=issue&itemId=46252222)